### PR TITLE
fix: corrige instância errada em leads e travamento do worker (erro 1006)

### DIFF
--- a/apps/api/src/modules/chatbot/service.ts
+++ b/apps/api/src/modules/chatbot/service.ts
@@ -1343,7 +1343,12 @@ private async evaluateConfig(
 
       try {
         alertSent = alertPhone
-          ? (await this.platformAlertService?.sendAlertToPhone(alertPhone, alertMessage)) ?? false
+          ? (await this.platformAlertService?.sendInstanceAlert(
+              tenantId,
+              conversation.instanceId,
+              alertPhone,
+              alertMessage
+            )) ?? false
           : false;
       } catch (error) {
         console.error(

--- a/apps/api/src/modules/instances/baileys-session.worker.ts
+++ b/apps/api/src/modules/instances/baileys-session.worker.ts
@@ -236,7 +236,13 @@ const scheduleDecryptFailureRecovery = (): void => {
       });
     }
 
-    await scheduleReconnect("Rajada de Bad MAC detectada");
+    try {
+      await scheduleReconnect("Rajada de Bad MAC detectada");
+    } catch (error) {
+      log("error", "Falha ao agendar reconexao apos rajada de decrypt", {
+        error: error instanceof Error ? error.message : "unknown"
+      });
+    }
   })().finally(() => {
     decryptFailureRecoveryPromise = null;
   });
@@ -837,7 +843,13 @@ const startSocket = async (): Promise<void> => {
       log("error", "Falha ao iniciar o socket da instancia", {
         error: message
       });
-      await scheduleReconnect(message);
+      try {
+        await scheduleReconnect(message);
+      } catch (reconnectError) {
+        log("error", "Falha ao agendar reconexao apos erro de inicializacao", {
+          error: reconnectError instanceof Error ? reconnectError.message : "unknown"
+        });
+      }
     }
   })();
 
@@ -1048,4 +1060,19 @@ parentPort?.on("message", async (command: IncomingCommand) => {
   process.exit(0);
 });
 
-void startSocket();
+process.on("unhandledRejection", (reason) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  log("error", "Promise rejeitada sem tratamento no worker", {
+    reason: message
+  });
+
+  if (!stopping) {
+    scheduleReconnect(message).catch(() => undefined);
+  }
+});
+
+startSocket().catch((error) => {
+  log("error", "Falha nao tratada ao iniciar o socket", {
+    error: error instanceof Error ? error.message : String(error)
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug #1 — Lead pelo número errado**: `processLeadAfterConversation` usava `sendAlertToPhone` que internamente chama `getAnyConnectedInstance()`, podendo usar a instância de qualquer tenant para enviar o lead. Corrigido para `sendInstanceAlert(tenantId, conversation.instanceId, ...)`, garantindo que o envio use sempre a instância correta.
- **Bug #2 — Instância trava (erro 1006 UnhandledPromiseRejection)**: fechamento anormal do WebSocket (código 1006) gerava `UnhandledPromiseRejection` sem handler, que no Node 15+ mata o worker thread — congelando a instância. Corrigido em três pontos sem try-catch (`scheduleDecryptFailureRecovery`, catch block de `startSocket`, `void startSocket()`) e adicionado handler global `process.on('unhandledRejection')` como última linha de defesa.

## Test plan

- [ ] Gerar um lead numa instância conectada e confirmar que a mensagem chega ao número de leads vinda do número **da própria instância**
- [ ] Verificar que nenhum outro tenant/instância é usado para enviar o lead
- [ ] Ativar o módulo de aprendizado contínuo, configurar admin e enviar o código de verificação — confirmar que a instância **não trava** após o código ser enviado
- [ ] Simular desconexão WebSocket e verificar que o worker registra o erro no log e tenta reconexão em vez de travar

🤖 Generated with [Claude Code](https://claude.com/claude-code)